### PR TITLE
Change to not leave the room if the bot had already left the room

### DIFF
--- a/Sources/SwiftChatSE/ChatRoom.swift
+++ b/Sources/SwiftChatSE/ChatRoom.swift
@@ -371,8 +371,8 @@ open class ChatRoom: NSObject {
 		//we don't really care if this fails
 		//...right?
 		
-		//Checking if the bot has already left the room: http://stackoverflow.com/a/38907719/4688119
-		if !(inRoom ?? false) { return } 
+		//Checking if the bot has already left the room
+		guard inRoom else { return }
 		
 		inRoom = false
 		let _ = try? client.post("https://chat.\(client.host.rawValue)/chats/leave/\(roomID)", ["quiet":"true","fkey":client.fkey]) as String

--- a/Sources/SwiftChatSE/ChatRoom.swift
+++ b/Sources/SwiftChatSE/ChatRoom.swift
@@ -370,6 +370,10 @@ open class ChatRoom: NSObject {
 	open func leave() {
 		//we don't really care if this fails
 		//...right?
+		
+		//Checking if the bot has already left the room: http://stackoverflow.com/a/38907719/4688119
+		if !(inRoom ?? false) { return } 
+		
 		inRoom = false
 		let _ = try? client.post("https://chat.\(client.host.rawValue)/chats/leave/\(roomID)", ["quiet":"true","fkey":client.fkey]) as String
 		ws.disconnect()


### PR DESCRIPTION
There was a bug in here which caused the command `leave room` to fail: the library leaves the room when the function `leave` is called without checking if the bot is in the room or not. I made a commit [based on this answer](http://stackoverflow.com/a/38907719/4688119) to fix this.

**Please review this change before merging as I am not experienced in Swift.**