### PR TITLE
Ping me too

### DIFF
--- a/Sources/SwiftChatSE/ErrorHandler.swift
+++ b/Sources/SwiftChatSE/ErrorHandler.swift
@@ -2,7 +2,7 @@
 //  ErrorHandler.swift
 //  FireAlarm
 //
-//  Created by Jonathan Keller on 11/22/16.
+//  Created by NobodyNada on 11/22/16.
 //  Copyright © 2016 NobodyNada. All rights reserved.
 //
 
@@ -35,7 +35,7 @@ public var afterTooManyErrors: () -> () = { abort() }
 public var errorsInLast30Seconds = 0
 
 ///A string that will be appended to the error message so that the bot's author can be pinged by errors..
-public var ping = " (cc @NobodyNada)"
+public var ping = " (cc @AshishAhuja @NobodyNada)"
 
 ///Logs an error.
 public func handleError(_ error: Error, _ context: String? = nil) {


### PR DESCRIPTION
I [recently made a change](https://github.com/SOBotics/FireAlarm/issues/6) to ping only the instance owner (defined in `location.txt`) instead of having a hardcoded username. This _should_ work (tests went fine), but in cases where `location.txt` is not present, I made a change to ping me and NobodyNada.