### PR TITLE
Enhancements to the `stop` and `reboot` command

### DIFF
--- a/Sources/SwiftChatSE/ChatListener.swift
+++ b/Sources/SwiftChatSE/ChatListener.swift
@@ -82,6 +82,10 @@ open class ChatListener {
 	fileprivate func handleCommand(_ message: ChatMessage) {
 		var components = message.content.lowercased().components(separatedBy: CharacterSet.whitespaces)
 		components.removeFirst()
+        
+		for i in 0..<components.count {
+			components[i] = components[i].trimmingCharacters(in: .punctuationCharacters)
+		}
 		
 		var args = [String]()
 		

--- a/Sources/SwiftChatSE/Client.swift
+++ b/Sources/SwiftChatSE/Client.swift
@@ -49,12 +49,19 @@ func += <K, V> (left: inout [K:V], right: [K:V]) {
 ///A Client handles HTTP requests, cookie management, and logging in to Stack Exchange chat.
 open class Client: NSObject, URLSessionDataDelegate {
 	//MARK: Instance variables
-	open var session: URLSession!
+	open var session: URLSession {
+		return URLSession(
+			configuration: configuration,
+			delegate: self, delegateQueue: delegateQueue
+		)
+	}
 	open var cookies = [HTTPCookie]()
 	open let queue = DispatchQueue(label: "Client queue")
 	
 	open var loggedIn = false
 	
+	private var configuration: URLSessionConfiguration
+	private var delegateQueue: OperationQueue
 	
 	fileprivate var _fkey: String!
 	
@@ -296,8 +303,8 @@ open class Client: NSObject, URLSessionDataDelegate {
 	}
 	
 	private func performTask(_ task: URLSessionTask, completion: @escaping (Data?, HTTPURLResponse?, Error?) -> Void) {
-		tasks[task] = HTTPTask(task: task, completion: completion)
 		usleep(500 * 1000)
+		tasks[task] = HTTPTask(task: task, completion: completion)
 		task.resume()
 	}
 	
@@ -465,6 +472,12 @@ open class Client: NSObject, URLSessionDataDelegate {
 		self.host = host
 		
 		let configuration =  URLSessionConfiguration.default
+		configuration.httpCookieStorage = nil
+		self.configuration = configuration
+		
+		let delegateQueue = OperationQueue()
+		delegateQueue.maxConcurrentOperationCount = 1
+		self.delegateQueue = delegateQueue
 		
 		super.init()
 		
@@ -477,16 +490,6 @@ open class Client: NSObject, URLSessionDataDelegate {
 		kCFNetworkProxiesHTTPSProxy as AnyHashable : "192.168.1.234",
 		kCFNetworkProxiesHTTPSPort as AnyHashable : 8080
 		]*/
-		
-		configuration.httpCookieStorage = nil
-		
-		let delegateQueue = OperationQueue()
-		delegateQueue.maxConcurrentOperationCount = 1
-		
-		session = URLSession(
-			configuration: configuration,
-			delegate: self, delegateQueue: delegateQueue
-		)
 	}
 	
 	

--- a/Sources/SwiftChatSE/CommandStop.swift
+++ b/Sources/SwiftChatSE/CommandStop.swift
@@ -11,7 +11,7 @@ import Foundation
 open class CommandStop: Command {
     fileprivate let REBOOT_INDEX = 4
     override open class func usage() -> [String] {
-        return ["stop", "halt", "shutdown", "shut down", "restart", "reboot"]
+        return ["stop ...", "halt ...", "shutdown ...", "shut down ...", "restart ...", "reboot ..."]
     }
 	
 	override open class func privileges() -> ChatUser.Privileges {
@@ -21,15 +21,50 @@ open class CommandStop: Command {
     override open func run() throws {
         let action: ChatListener.StopReason
         let reply: String
-        if usageIndex < REBOOT_INDEX {
-            action = .halt
-            reply = "Shutting down..."
+        
+        let argLocation: String
+    
+        if arguments.count == 0 {
+            if usageIndex < REBOOT_INDEX {
+                action = .halt
+                reply = "Shutting down..."
+            }
+            else {
+                action = .reboot
+                reply = "Rebooting..."
+            }
+            
+            self.reply(reply)
+            listener.stop(action)
+            
+            return
+        } else {
+            argLocation = arguments [0].lowercased()
         }
-        else {
-            action = .reboot
-            reply = "Rebooting..."
+        
+        if (userLocation == "<unknown>")
+        {
+            self.reply ("Location is set to unknown!")
+            return
         }
-        self.reply(reply)
-        listener.stop(action)
+        
+        //self.reply (argLocation)
+        //self.reply (userLocation)
+        
+        if (userLocation.lowercased() == argLocation) {
+            if usageIndex < REBOOT_INDEX {
+                action = .halt
+                reply = "Shutting down..."
+            }
+            else {
+                action = .reboot
+                reply = "Rebooting..."
+            }
+            
+            self.reply(reply)
+            listener.stop(action)
+            
+            return
+        }
     }
 }

--- a/Sources/SwiftChatSE/Utilites.swift
+++ b/Sources/SwiftChatSE/Utilites.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dispatch
 
-
+public var userLocation = "<unknown>"
 
 public enum FileLoadingError: Error {
 	case notUFT8


### PR DESCRIPTION
Made some changes to enhance the `stop` and `reboot` command to allow stopping a specific instance if more than 1 instance is running at the same time. After this is merged, doing something like `stop Ashish/Mac` will only stop the bot instance with the location specified, while `stop` will stop all instances.